### PR TITLE
Build Final CTA Section with Dual Button Layout

### DIFF
--- a/auralex-frontend/src/app/page.tsx
+++ b/auralex-frontend/src/app/page.tsx
@@ -4,6 +4,8 @@ import HeroSection from "@/components/sections/HeroSection";
 import FeaturesSection from "@/components/sections/FeaturesSection";
 import BenefitsSection from "@/components/sections/BenefitsSection";
 import { Web3Section } from "@/components/sections";
+import CTASection from "@/components/sections/CTASection";
+
 
 const HomePage = () => {
   return (
@@ -12,8 +14,11 @@ const HomePage = () => {
       <FeaturesSection />
       <BenefitsSection />
       <Web3Section />
+      <CTASection />
     </main>
   );
 };
 
 export default HomePage;
+
+

--- a/auralex-frontend/src/components/sections/CTASection.tsx
+++ b/auralex-frontend/src/components/sections/CTASection.tsx
@@ -1,10 +1,28 @@
 import React from 'react'
+import { Heart, ChevronRight } from 'lucide-react'
 
 const CTASection = () => {
   return (
-    <div>
-      
-    </div>
+    <section className="py-20 bg-gradient-to-r from-indigo-600 to-purple-600">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-4xl font-bold text-white mb-6">
+            Ready to Transform Learning?
+          </h2>
+          <p className="text-xl text-indigo-100 mb-8 max-w-2xl mx-auto">
+            Join thousands of students already experiencing personalized, AI-powered education designed specifically for dyslexic learners.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <button className="bg-white text-indigo-600 px-8 py-4 rounded-full font-semibold hover:shadow-xl transform hover:scale-105 transition-all duration-200 flex items-center justify-center">
+              <Heart className="h-5 w-5 mr-2" />
+              Start Free Trial
+            </button>
+            <button className="border-2 border-white text-white px-8 py-4 rounded-full font-semibold hover:bg-white hover:text-indigo-600 transition-all duration-200 flex items-center justify-center">
+              Learn More
+              <ChevronRight className="h-5 w-5 ml-2" />
+            </button>
+          </div>
+        </div>
+      </section>
   )
 }
 


### PR DESCRIPTION
### ✨ Feature: Final CTA Section Implementation

This PR implements the final **Call-to-Action (CTA) section** designed to convert site visitors into users with visually appealing content and clearly defined actions.

---

### ✅ What's Included

* **File modified:** `src/components/sections/CTASection.tsx`
* Gradient background: `from-indigo-600 to-purple-600`
* Centered content using `max-w-4xl mx-auto` for layout consistency
* **Typography:**

  * Headline and benefit-focused subtext with white text on dark background
  * Includes social proof hint: “Join thousands of students”
* **CTA Buttons:**

  * Primary: “Start Free Trial” → white background, indigo text, with ❤️ Heart icon
  * Secondary: “Learn More” → transparent with border, white text, with ➡️ ChevronRight icon
* Responsive layout: Buttons stack vertically on mobile (`flex-col`) and horizontally on larger screens (`sm:flex-row`)

---

### 📱 Preview

![CTA Section Preview](url-to-screenshot-if-any)

---

### 📌 Notes

* Follows all design specifications as described in issue #5
* Ready for review and merge

---

#5 